### PR TITLE
Cambios necesarios para executar co built-in server de php en docker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.{php,js,css,scss}]
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+vendor/
+yarn.lock
+src/assets/script.min.js
+src/assets/style.css
+src/assets/style.css.map

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contorno de Desenvolvemento con Docker
+
+Para a posta en marcha en local só é necesario ter instalado `git` e `docker`. Os seguintes comandos foron executados co usuario habitual nun contorno ubuntu-like, polo que o UID e GID de usuario é 1000; cambiar segundo corresponda (pódese averiguar facil co comando `id`)
+
+## Descargamos o código e iniciamos o servidor.
+
+- Dos seguintes comandos, se algún fallase, poderíanselle agregar os flags `--interactive --tty` por se fixera falta algunha interacción.
+- Pódese usar npm e yarn de xeito indistinto.
+- Clonamos o código
+    ```
+    git clone https://github.com/YOUR-USER/galipsum/
+    cd galipsum
+    git remote add upstream https://github.com/unapersona/galipsum/
+    git fetch upstream
+    ```
+- Descargamos dependencias
+    ```
+    docker run --rm -v $PWD:/app -w /app --user 1000:1000 composer install
+    docker run --rm -v $PWD:/app -w /app --user 1000:1000 node:buster-slim npm install
+    ```
+- Se o `npm install` falla por timeout, pódese probar con `yarn` en vez de `npm` (pero entón habería que utilizar `yarn` tamén nos seguintes comandos).
+- Xeramos os artefactos de producción
+    ```
+    docker run --rm -v $PWD:/app -w /app --user 1000:1000 node:buster-slim npm scripts
+    docker run --rm -v $PWD:/app -w /app --user 1000:1000 node:buster-slim npm styles
+    ```
+- Iniciamos a aplicación co servidor integrado de PHP
+    ```
+    docker run --rm -v $PWD:/app -w /app --user 1000:1000 -p 127.0.0.1:8080:8080 php:7.4-cli php -S 0.0.0.0:8080 index.php
+    ```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,12 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "esbuild": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.6.5.tgz",
+      "integrity": "sha512-glMZd0b6W2soHuUuchM6c55e6gbdDhVpvYcmLsH3OJo87hQZcb3lFPZAJ5MbzLCJa2bChQOaoC4bqVtbqfsM/A==",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cash-dom": "^8.0.0",
     "chota": "^0.8.0",
     "clipboard": "^2.0.6",
+    "esbuild": "^0.6.5",
     "node-sass": "^4.14.1"
   }
 }

--- a/src/app.php
+++ b/src/app.php
@@ -22,6 +22,10 @@ $klein->respond('/src/assets/[script.min.js|style.css|style.css.map|galipsum.svg
     $response->file('./src/assets/' . $request->filename, $request->filename, $mime);
 });
 
+$klein->respond('/favicon.ico', function ($request, $response, $service) {
+    $response->file('./favicon.ico', 'favicon.ico', 'image/vnd.microsoft.icon');
+});
+
 $klein->respond('GET', '/', function (\Klein\Request $request, \Klein\Response $response, \Klein\ServiceProvider $service, \Klein\App $app){
 	$service->title = 'GALipsum | Xerador de textos de recheo en galego';
 	$service->render(__DIR__ . '/templates/app.php');

--- a/src/app.php
+++ b/src/app.php
@@ -8,6 +8,20 @@ $klein->respond(function (\Klein\Request $request, \Klein\Response $response, \K
 	$service->texts = require 'data/text.php';
 });
 
+$klein->respond('/src/assets/[script.min.js|style.css|style.css.map|galipsum.svg:filename]', function ($request, $response, $service) {
+    $mime = null;
+    if(preg_match('/(css|css.map)$/', $request->filename)) {
+        $mime = 'text/css';
+    }
+    else if(preg_match('/(js|js.map)$/', $request->filename)) {
+        $mime = 'text/javascript';
+    }
+    else if(preg_match('/(svg)$/', $request->filename)) {
+        $mime = 'image/svg+xml';
+    }
+    $response->file('./src/assets/' . $request->filename, $request->filename, $mime);
+});
+
 $klein->respond('GET', '/', function (\Klein\Request $request, \Klein\Response $response, \Klein\ServiceProvider $service, \Klein\App $app){
 	$service->title = 'GALipsum | Xerador de textos de recheo en galego';
 	$service->render(__DIR__ . '/templates/app.php');


### PR DESCRIPTION
Cambios necesarios que tiven que realizar para poder executar en local a través de docker

`docker run --rm --interactive --tty -v $PWD:/app -w /app --user 1000:1000 -p 127.0.0.1:8080:8080 php:7.4-cli php -S 0.0.0.0:8080 index.php`

Como no meu equipo npm deume continuamente problemas de timeout e non din instalado as dependecias, tiven que acabar usando yarn, por iso incluin o yarn.lock no .gitignore.

Tamén me pareceu util meter no .gitignore vendor/ node_modules/ e os artefactos de producción.

Para poder xerar o js, tiven que engadir esbuild como dependencia de desarrollo. Supoño que ti a terás instalada como global.